### PR TITLE
Adapt to Qt5Xdg new way of finding the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ endif()
 if(SG_EXT_EDIT)
     add_definitions( -DSG_EXT_EDIT="1")
     find_package(Qt5Xdg REQUIRED)
-    include(${QTXDG_USE_FILE})
 endif()
 
 if(SG_DBUS_NOTIFY)

--- a/src/modules/extedit/CMakeLists.txt
+++ b/src/modules/extedit/CMakeLists.txt
@@ -34,4 +34,4 @@ add_library(extedit
 set_property (TARGET extedit PROPERTY SOVERSION 1.0.0)
 install(TARGETS extedit DESTINATION ${SG_LIBDIR})
 
-target_link_libraries(extedit Qt5::Widgets Qt5::X11Extras ${QTXDG_LIBRARIES})
+target_link_libraries(extedit Qt5::Widgets Qt5::X11Extras Qt5Xdg)


### PR DESCRIPTION
Qt5Xdg dropped the include(${QT_USE_FILE}) way.
Use Qt5Xdg instead of QTXDG_LIBRARIES.