### PR TITLE
Adds "snap to border" functionality

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -56,6 +56,7 @@
 #define KEY_ENABLE_EXT_VIEWER   "enbaleExternalView"
 #define KEY_NODECOR             "noDecorations"
 #define KEY_INCLUDE_CURSOR      "includeCursor"
+#define KEY_FIT_INSIDE          "fitInside"
 
 
 static const QLatin1String FullScreen("FullScreen");
@@ -455,6 +456,16 @@ void Config::setNoDecoration(bool val)
     setValue(KEY_NODECOR, val);
 }
 
+bool Config::getFitInside()
+{
+    return value(KEY_FIT_INSIDE).toBool();
+}
+
+void Config::setFitInside(bool val)
+{
+    setValue(KEY_FIT_INSIDE, val);
+}
+
 void Config::saveWndSize()
 {
     // saving size
@@ -497,6 +508,7 @@ void Config::loadSettings()
     setCloseInTray(_settings->value(KEY_CLOSE_INTRAY, DEF_CLOSE_IN_TRAY).toBool());
     setAllowMultipleInstance(_settings->value(KEY_ALLOW_COPIES, DEF_ALLOW_COPIES).toBool());
     setEnableExtView(_settings->value(KEY_ENABLE_EXT_VIEWER, DEF_ENABLE_EXT_VIEWER).toBool());
+    setFitInside(_settings->value(KEY_FIT_INSIDE, DEF_FIT_INSIDE).toBool());
     _settings->endGroup();
 
     setDelay(getDefDelay());
@@ -534,6 +546,7 @@ void Config::saveSettings()
     _settings->setValue(KEY_CLOSE_INTRAY, getCloseInTray());
     _settings->setValue(KEY_ALLOW_COPIES, getAllowMultipleInstance());
     _settings->setValue(KEY_ENABLE_EXT_VIEWER, getEnableExtView());
+    _settings->setValue(KEY_FIT_INSIDE, getFitInside());
     _settings->endGroup();
 
     _shortcuts->saveSettings();
@@ -565,6 +578,7 @@ void Config::setDefaultSettings()
     // setRestoredWndSize(DEF_WND_WIDTH, DEF_WND_HEIGHT);
     setShowTrayIcon(DEF_SHOW_TRAY);
     setEnableExtView(DEF_ENABLE_EXT_VIEWER);
+    setFitInside(DEF_FIT_INSIDE);
 
     _shortcuts->setDefaultSettings();
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -50,6 +50,7 @@ const QString DEF_DATETIME_TPL = "yyyy-MM-dd-hh-mm-ss";
 const bool DEF_SHOW_TRAY = true;
 const bool DEF_ENABLE_EXT_VIEWER = true;
 const bool DEF_INCLUDE_CURSOR = false;
+const bool DEF_FIT_INSIDE = true;
 
 // class worker with conf data
 class Config
@@ -224,6 +225,9 @@ public:
 
     bool getIncludeCursor();
     void setIncludeCursor(bool val);
+
+    bool getFitInside();
+    void setFitInside(bool val);
 
     static QString getSysLang();
 

--- a/src/core/regionselect.h
+++ b/src/core/regionselect.h
@@ -30,6 +30,13 @@
 #include <QSize>
 #include <QPoint>
 
+enum Side{
+    TOP,
+    RIGHT,
+    BOTTOM,
+    LEFT
+};
+
 // class RegionSelect : public QDialog
 class RegionSelect : public QWidget
 {
@@ -59,7 +66,11 @@ private:
     QPoint _selStartPoint;
     QPoint _selEndPoint;
 
+    int _currentFit;
+    QVector<QRect> _fitRectangles;
+
     bool _processSelection;
+    bool _fittedSelection;
 
     QPixmap _desktopPixmapBkg;
     QPixmap _desktopPixmapClr;
@@ -67,8 +78,14 @@ private:
     void sharedInit();
     void drawBackGround();
     void drawRectSelection(QPainter &painter);
+    void selectFit();
+    void findFit();
+    void fitBorder(const QRect &boundRect, enum Side side, int &border);
 
     Config *_conf;
+
+    const int fitRectExpand = 20;
+    const int fitRectDepth = 50;
 
 };
 

--- a/src/core/ui/configwidget.cpp
+++ b/src/core/ui/configwidget.cpp
@@ -176,6 +176,8 @@ void ConfigDialog::loadSettings()
 
     _ui->slideImgQuality->setValue(conf->getImageQuality());
     _ui->cbxEnableExtView->setChecked(conf->getEnableExtView());
+
+    _ui->checkFitInside->setChecked(conf->getFitInside());
 }
 
 
@@ -268,6 +270,7 @@ void ConfigDialog::saveSettings()
     conf->setImageQuality(_ui->slideImgQuality->value());
     conf->setEnableExtView(_ui->cbxEnableExtView->isChecked());
     conf->setNoDecoration(_ui->checkNoDecorX11->isChecked());
+    conf->setFitInside(_ui->checkFitInside->isChecked());
 
     // save shortcuts in shortcutmanager
     int action = 0;

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -580,6 +580,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="checkFitInside">
+           <property name="toolTip">
+            <string>Fit to edges only inside selected screen area</string>
+           </property>
+           <property name="text">
+            <string>Fit to edges inside selected area</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Recognizes a rectangular area inside the selected region and automatically snaps the screenshot selection
Feature activated by right click selection or pressing space (also toggles "snap selection")
Added new menu entry to enable "snapping" outside the selected region

See it in action https://www.youtube.com/watch?v=Y4Gb7NgOPLI&t